### PR TITLE
Fixed Persisted Updating through #{singular}_list= (currently does not update frozen_{singular}_list)

### DIFF
--- a/lib/dm-tags/dm_tags.rb
+++ b/lib/dm-tags/dm_tags.rb
@@ -57,6 +57,8 @@ module DataMapper
 
             def #{singular}_list=(string)
               @#{singular}_list = string.to_s.split(',').map { |name| name.gsub(/[^\\w\\s_-]/i, '').strip }.uniq.sort
+              
+              update_#{association}
             end
 
             alias_method :#{singular}_collection=, :#{singular}_list=

--- a/lib/dm-tags/tagging.rb
+++ b/lib/dm-tags/tagging.rb
@@ -8,6 +8,10 @@ class Tagging
 
   belongs_to :tag
 
+  # Datamapper doesnt throw the next line in apparently,
+  # or theres an error before it gets added..whatever
+  property :tag_id, Integer
+
   def taggable
     taggable_type.get!(taggable_id)
   end


### PR DESCRIPTION
The problem is that updating with 'tag_list=' does not reflect changes onto @frozen_tag_list, and therefore the updated list never gets properly persisted in the database (which has a frozen_tag_list field).

  model.tag_list = 'test, me out,   please   '
  model.tag_list #=> ['me out', 'please', 'test'] # Sanitized and alphabetized
  model.save #=> true

  model.tag_list = 'test, again'
  model.save #=> true

  # But if we pull it back from storage, the update is lost.
  model = MyModel.get(model.id)
  model.tag_list #=> ['me out', 'please', 'test'] # NOT UPDATED TO ['test', 'again']

Simply called 'update_#{collection}' at the end of '#{singular}_list=' to handle this.

This was a problem I had with 1.0.2 and older, so it may be resolved now.
